### PR TITLE
add watchdog

### DIFF
--- a/solarmon.service
+++ b/solarmon.service
@@ -7,6 +7,7 @@ ExecStart=/usr/bin/python3 -u solarmon.py
 WorkingDirectory=/home/pi/solarmon
 StandardOutput=inherit
 StandardError=inherit
+WatchdogSec=60
 Restart=always
 User=pi
 


### PR DESCRIPTION
service will restart after 60 seconds, this will prevent solarmon from crashing ('ModbusIOException' object has no attribute 'registers')