### PR TITLE
chore: port to pymodbus 3.8.6 (Python 3.9 compatible)

### DIFF
--- a/growatt.py
+++ b/growatt.py
@@ -100,7 +100,7 @@ def _read_input_safe(client, unit, start, count, retries=2, delay=0.05):
     """
     for _ in range(retries + 1):
         try:
-            resp = client.read_input_registers(start, count, unit=unit)
+            resp = client.read_input_registers(start, count=count, slave=unit)
             if _resp_ok(resp):
                 return resp
         except Exception:
@@ -124,7 +124,7 @@ class Growatt:
     def read_info(self):
         """Read modbus version. Non-fatal if inverter is offline (e.g. nighttime)."""
         try:
-            row = self.client.read_holding_registers(73, 1, unit=self.unit)
+            row = self.client.read_holding_registers(73, count=1, slave=self.unit)
             if _resp_ok(row):
                 self.modbusVersion = row.registers[0]
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-#pymodbus==3.1.2
-pymodbus==2.5.3
+# pymodbus 3.9+ requires Python >=3.10; 3.8.6 is the last 3.x supporting Python 3.9 (Raspberry Pi / Debian 11)
+pymodbus==3.8.6
 paho-mqtt>=2.1.0

--- a/solarmon.py
+++ b/solarmon.py
@@ -6,7 +6,7 @@ import json
 import socket
 
 from configparser import RawConfigParser
-from pymodbus.client.sync import ModbusSerialClient as ModbusClient
+from pymodbus.client import ModbusSerialClient as ModbusClient
 from growatt import Growatt
 
 # --- Optional MQTT (paho-mqtt) ---
@@ -154,7 +154,7 @@ error_interval = settings.getint('query', 'error_interval', fallback=60)
 # Serial connection
 print('Setup Serial Connection... ', end='')
 port = settings.get('solarmon', 'port', fallback='/dev/ttyUSB0')
-client = ModbusClient(method='rtu', port=port, baudrate=9600, stopbits=1, parity='N', bytesize=8, timeout=1)
+client = ModbusClient(port=port, baudrate=9600, stopbits=1, parity='N', bytesize=8, timeout=1)
 client.connect()
 print('Done!')
 


### PR DESCRIPTION
Alternative to #25. PR #25 bumps pymodbus to 3.13.1, which **requires Python >=3.10** and therefore cannot install on the target Raspberry Pi (Debian 11 / Python 3.9.2).

This pins pymodbus to **3.8.6** — the last 3.x release supporting Python 3.9 — and ports the code to the pymodbus 3.x API:

- solarmon.py: import `ModbusSerialClient` from `pymodbus.client` (the old `pymodbus.client.sync` module was removed in 3.x)
- solarmon.py: drop `method='rtu'` from the constructor (RTU is the default serial framer in 3.x)
- growatt.py: use keyword-only `count=` and `slave=` on `read_input_registers` / `read_holding_registers` (positional `count` and `unit=` are gone)

### Validation
- `py_compile` passes for both modules under pymodbus 3.8.6
- `import growatt` resolves all pymodbus imports (`pymodbus.exceptions`, `pymodbus.pdu`) under 3.8.6

Note: paho-mqtt still emits the harmless `Callback API version 1 is deprecated` warning; that is unrelated and can be cleaned up separately.

Suggest closing #25 in favor of this.