### PR TITLE
chore: silence paho-mqtt v1 callback deprecation warning

### DIFF
--- a/solarmon.py
+++ b/solarmon.py
@@ -31,7 +31,7 @@ def mqtt_setup(cfg):
     base = cfg.get('mqtt', 'base_topic', fallback='solar/inverter').rstrip('/')
 
     client_id = f"solarmon-{socket.gethostname()}"
-    client = mqtt.Client(client_id=client_id, clean_session=True)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=client_id, clean_session=True)
     if username:
         client.username_pw_set(username, password or None)
 


### PR DESCRIPTION
Removes the runtime warning seen on the production Pi after merging #24:

`DeprecationWarning: Callback API version 1 is deprecated, update to latest version` at `solarmon.py:34`.

paho-mqtt 2.x emits this whenever a `Client` is constructed without an explicit `callback_api_version`. This passes `mqtt.CallbackAPIVersion.VERSION2`. The code registers **no** MQTT callbacks (`on_connect`/`on_message` etc.), so VERSION2 is behavior-identical — only `connect`, `loop_start`, `publish`, `will_set` and `username_pw_set` are used, and their signatures are unchanged.

### Validation (against paho-mqtt 2.1.0)
- Constructing with `VERSION2` + `will_set` + `username_pw_set` raises **no** `DeprecationWarning` (tested with `-W error::DeprecationWarning`).
- Confirmed that explicit `VERSION1` does *not* silence the warning (paho warns for v1 regardless), so v2 is required.
- `py_compile` passes.

Independent of the pymodbus work in #26; safe to merge on its own.