### PR TITLE
Silence paho-mqtt v1 callback deprecation warning

### DIFF
--- a/solarmon.py
+++ b/solarmon.py
@@ -31,7 +31,7 @@ def mqtt_setup(cfg):
     base = cfg.get('mqtt', 'base_topic', fallback='solar/inverter').rstrip('/')
 
     client_id = f"solarmon-{socket.gethostname()}"
-    client = mqtt.Client(client_id=client_id, clean_session=True)
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=client_id, clean_session=True)
     if username:
         client.username_pw_set(username, password or None)
 


### PR DESCRIPTION
This pull request updates the MQTT client initialization in `solarmon.py` to specify the MQTT callback API version. This change ensures compatibility with newer versions of the `paho-mqtt` library.

MQTT client initialization:

* Updated the `mqtt.Client` constructor to explicitly set the callback API version to `mqtt.CallbackAPIVersion.VERSION2` for improved compatibility.