### PR TITLE
Port to pymodbus 3.8.6 for Python 3.9 compatibility

### DIFF
--- a/growatt.py
+++ b/growatt.py
@@ -100,7 +100,7 @@ def _read_input_safe(client, unit, start, count, retries=2, delay=0.05):
     """
     for _ in range(retries + 1):
         try:
-            resp = client.read_input_registers(start, count, unit=unit)
+            resp = client.read_input_registers(start, count=count, slave=unit)
             if _resp_ok(resp):
                 return resp
         except Exception:
@@ -124,7 +124,7 @@ class Growatt:
     def read_info(self):
         """Read modbus version. Non-fatal if inverter is offline (e.g. nighttime)."""
         try:
-            row = self.client.read_holding_registers(73, 1, unit=self.unit)
+            row = self.client.read_holding_registers(73, count=1, slave=self.unit)
             if _resp_ok(row):
                 self.modbusVersion = row.registers[0]
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-#pymodbus==3.1.2
-pymodbus==2.5.3
+# pymodbus 3.9+ requires Python >=3.10; 3.8.6 is the last 3.x supporting Python 3.9 (Raspberry Pi / Debian 11)
+pymodbus==3.8.6
 paho-mqtt>=2.1.0

--- a/solarmon.py
+++ b/solarmon.py
@@ -6,7 +6,7 @@ import json
 import socket
 
 from configparser import RawConfigParser
-from pymodbus.client.sync import ModbusSerialClient as ModbusClient
+from pymodbus.client import ModbusSerialClient as ModbusClient
 from growatt import Growatt
 
 # --- Optional MQTT (paho-mqtt) ---
@@ -154,7 +154,7 @@ error_interval = settings.getint('query', 'error_interval', fallback=60)
 # Serial connection
 print('Setup Serial Connection... ', end='')
 port = settings.get('solarmon', 'port', fallback='/dev/ttyUSB0')
-client = ModbusClient(method='rtu', port=port, baudrate=9600, stopbits=1, parity='N', bytesize=8, timeout=1)
+client = ModbusClient(port=port, baudrate=9600, stopbits=1, parity='N', bytesize=8, timeout=1)
 client.connect()
 print('Done!')
 


### PR DESCRIPTION
This pull request updates the codebase to improve compatibility with newer versions of the `pymodbus` library. The main changes involve updating import statements and modifying how Modbus client methods are called to match the updated API.

**pymodbus compatibility updates:**

* Changed the import statement in `solarmon.py` to use the new `pymodbus.client` import path for `ModbusSerialClient`.
* Removed the deprecated `method='rtu'` argument from the `ModbusClient` constructor in `solarmon.py`.

**Modbus method signature updates:**

* Updated calls to `read_input_registers` and `read_holding_registers` in `growatt.py` to use the `count` and `slave` keyword arguments instead of `count` and `unit`, per the new `pymodbus` API. [[1]](diffhunk://#diff-760287a1d691ea4984995efbd8291e61147ab0fb18c3fa7dc4390ecfd6bf2ff3L103-R103) [[2]](diffhunk://#diff-760287a1d691ea4984995efbd8291e61147ab0fb18c3fa7dc4390ecfd6bf2ff3L127-R127)